### PR TITLE
Feature/persisting wins

### DIFF
--- a/main.js
+++ b/main.js
@@ -91,6 +91,7 @@ function winningSlapPlayer0() {
   if(currentGame.slapJack()) {
     currentGame.players[0].wins++;
     saveGame();
+    gameReset(); 
   }
 };
 
@@ -99,6 +100,7 @@ function winningSlapPlayer1() {
     if(currentGame.slapJack()) {
       currentGame.players[0].wins++;
       saveGame();
+      gameReset();
     }
 };
 
@@ -119,6 +121,7 @@ function redemptionAttemptPlayer0() {
 } else {
     currentGame.players[1].wins++;
     saveGame();
+    gameReset();
   }
 };
 
@@ -129,6 +132,7 @@ function redemptionAttemptPlayer1() {
 } else {
     currentGame.players[0].wins++;
     saveGame();
+    gameReset();
   }
 };
 


### PR DESCRIPTION
## Is this a fix or a feature?

- Feature

## What is the change?

- Local storage is utilized to save player instances 
- After a win condition is met, both players are stored to local storage, and the game is reset
- The wins for each player will be saved 
- Upon reload, the wins will persist and be saved in local Storage

## What does it fix?

- N/A

## Where should the reviewer start?

-main.js lines: 
5, 
93-93, 
102-103, 
123-124, 
134-135, 
139-161
## How should this be tested?

- Refresh the page and check localStorage to make sure  it is empty, if not, clear storage
- Play a game until one player wins. 
- check Local Storage, now, both players should be saved into the local storage and the win should be updated for the winning player
- currentGame should now be reset with all cards shuffled and dealt out
- currentGame should now hold two players with persisting wins from the previous game
- Refresh the page, the currentGame should still be reset and current players should have persisting wins from the previous games
