### PR TITLE
Fix/message display empty pile

### DIFF
--- a/main.js
+++ b/main.js
@@ -213,6 +213,9 @@ function winnerDealsPlayer2() {
 };
 
 function winningSlapPlayer1() {
+  if(checkMiddlePile()) {
+    return;
+  }
   currentGame.whoSlapped = 1;
   if(currentGame.slapJack()) {
     displayWinningMessage("SLAPJACK", "player 1");
@@ -224,6 +227,9 @@ function winningSlapPlayer1() {
 };
 
 function winningSlapPlayer2() {
+  if(checkMiddlePile()) {
+    return;
+  }
   currentGame.whoSlapped = 2;
     if(currentGame.slapJack()) {
       displayWinningMessage("SLAPJACK", "player 2");
@@ -245,6 +251,9 @@ function redemptionSlap(event) {
 };
 
 function redemptionAttemptPlayer1() {
+  if(checkMiddlePile()) {
+    return;
+  }
   currentGame.whoSlapped = 1;
   if(currentGame.slapJack()) {
     display(playerPile1);
@@ -260,6 +269,9 @@ function redemptionAttemptPlayer1() {
 };
 
 function redemptionAttemptPlayer2() {
+  if(checkMiddlePile()) {
+    return; 
+  }
   currentGame.whoSlapped = 2;
   if(currentGame.slapJack()) {
     display(playerPile1);


### PR DESCRIPTION
## Is this a fix or a feature?
- Fix
## What is the change?
- N/A
## What does it fix?
- This fix will allow two players to attempt a slap at the same time. There is now a block in place that will prevent a player from slapping on a empty pile
- This will keep the winner's message on display
- The winner's message will now only disappear when the next card is dealt
## Where should the reviewer start?
- main.js: 112-116
## How should this be tested?
- When playing the game, two players should be able to attempt a slap on the jack, but only one player's message should appear if they slapped first. The message should not disappear until the next card is dealt. 
