### PR TITLE
Remove position absolute from body rule

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,7 +11,6 @@ html {
 body {
   height: 100%;
   background: linear-gradient(90deg, #de16a5, #f07b32 70%);
-  position: absolute;
 }
 
 h1 {


### PR DESCRIPTION
## Is this a fix or a feature?
- Fix
## What is the change?
## What does it fix?
- Remove unnecessary style property position absolute from body rule
## Where should the reviewer start?
style.css: lines 11-14
## How should this be tested?
- As a player deals cards, there should be no flash, card should appear without the layout changing
